### PR TITLE
[BUILD] Add test-jar goal to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,31 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>com/spatial4j/core/**/*</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.16</version>
         <configuration>


### PR DESCRIPTION
S4J includes nice helper methods for randomized spatial testing. These helper methods should be used/extended in derivitive spatial test suites to ensure consistency with s4j's core logic.  This commit adds the test-jar goal to the s4j pom to build a spatial4j-M.m.r-tests.jar for inclusion in the maven repository

Signed-off-by: Nicholas Knize <nknize@gmail.com>