### PR TITLE
Consistent use of ParseException vs InvalidShapeException

### DIFF
--- a/src/main/java/com/spatial4j/core/context/SpatialContext.java
+++ b/src/main/java/com/spatial4j/core/context/SpatialContext.java
@@ -315,7 +315,7 @@ public class SpatialContext {
    * @return non-null
    * @throws ParseException if it failed to parse.
    */
-  public Shape readShapeFromWkt(String wkt) throws ParseException {
+  public Shape readShapeFromWkt(String wkt) throws ParseException, InvalidShapeException {
     return getWktShapeParser().parse(wkt);
   }
 

--- a/src/main/java/com/spatial4j/core/io/WKTReader.java
+++ b/src/main/java/com/spatial4j/core/io/WKTReader.java
@@ -84,7 +84,7 @@ public class WKTReader implements ShapeReader {
    * @return Non-null Shape defined in the String
    * @throws ParseException Thrown if there is an error in the Shape definition
    */
-  public Shape parse(String wktString) throws ParseException {
+  public Shape parse(String wktString) throws ParseException, InvalidShapeException {
     Shape shape = parseIfSupported(wktString);// sets rawString & offset
     if (shape != null)
       return shape;
@@ -103,7 +103,7 @@ public class WKTReader implements ShapeReader {
    * @return Shape, null if unknown / unsupported shape.
    * @throws ParseException Thrown if there is an error in the Shape definition
    */
-  public Shape parseIfSupported(String wktString) throws ParseException {
+  public Shape parseIfSupported(String wktString) throws ParseException, InvalidShapeException {
     State state = newState(wktString);
     state.nextIfWhitespace();// leading
     if (state.eof())
@@ -117,7 +117,11 @@ public class WKTReader implements ShapeReader {
       result = parseShapeByType(state, shapeType);
     } catch (ParseException e) {
       throw e;
-    } catch (Exception e) {// most likely InvalidShapeException
+    } catch (InvalidShapeException e) {
+      throw e;
+    } catch (IllegalArgumentException e) { // JTS Throws IllegalArgment for bad WKT
+      throw new InvalidShapeException(e.getMessage(), e);
+    } catch (Exception e) {
       ParseException pe = new ParseException(e.toString(), state.offset);
       pe.initCause(e);
       throw pe;

--- a/src/test/java/com/spatial4j/core/io/JtsWktShapeParserTest.java
+++ b/src/test/java/com/spatial4j/core/io/JtsWktShapeParserTest.java
@@ -19,6 +19,7 @@ package com.spatial4j.core.io;
 
 import com.spatial4j.core.context.jts.JtsSpatialContext;
 import com.spatial4j.core.context.jts.JtsSpatialContextFactory;
+import com.spatial4j.core.exception.InvalidShapeException;
 import com.spatial4j.core.io.jts.JtsWKTReader;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
@@ -26,6 +27,7 @@ import com.spatial4j.core.shape.SpatialRelation;
 import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.GeometryFactory;
+
 import org.junit.Test;
 
 import java.text.ParseException;
@@ -143,20 +145,20 @@ public class JtsWktShapeParserTest extends WktShapeParserTest {
   }
 
   @Test
-  public void testWrapTopologyException() {
+  public void testWrapTopologyException() throws Exception {
     //test that we can catch ParseException without having to detect TopologyException too
     assert ((JtsWKTReader)ctx.getWktShapeParser()).isAutoValidate();
     try {
       ctx.readShapeFromWkt("POLYGON((0 0, 10 0, 10 20))");//doesn't connect around
       fail();
-    } catch (ParseException e) {
+    } catch (InvalidShapeException e) {
       //expected
     }
 
     try {
       ctx.readShapeFromWkt("POLYGON((0 0, 10 0, 10 20, 5 -5, 0 20, 0 0))");//Topology self-intersect
       fail();
-    } catch (ParseException e) {
+    } catch (InvalidShapeException e) {
       //expected
     }
   }

--- a/src/test/java/com/spatial4j/core/io/ShapeFormatTest.java
+++ b/src/test/java/com/spatial4j/core/io/ShapeFormatTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.context.jts.JtsSpatialContext;
+import com.spatial4j.core.exception.InvalidShapeException;
+import com.spatial4j.core.io.jts.JtsWKTReader;
 import com.spatial4j.core.shape.Shape;
 
 /**
@@ -75,9 +77,6 @@ public class ShapeFormatTest {
     ShapeWriter writer = ctx.getWriter(name);
     Shape shape = null;
     
-//    String wkt = readFirstLineFromRsrc("/fiji.wkt.txt");
-//    shape = ctx.readShape(wkt);
-//  //  testReadAndWriteTheSame(shape,format);
 //    
 //    wkt = readFirstLineFromRsrc("/russia.wkt.txt");
 //    shape = ctx.readShape(wkt);
@@ -119,6 +118,43 @@ public class ShapeFormatTest {
     testCommon(SpatialContext.GEO, format);
     testCommon(JtsSpatialContext.GEO, format);
     testJTS(JtsSpatialContext.GEO, format);
+  }
+  
+  public void testParseVsInvalidExceptions(WKTReader reader) throws Exception
+  {
+    String txt = null;
+    try {
+      txt = "garbage";
+      reader.read(txt);
+      fail("should throw invalid exception");
+    } catch(ParseException ex) { 
+      //expected
+    }
+    
+    try {
+      txt = "POINT(-1000 1000)";
+      reader.read(txt);
+      fail("should throw invalid shape");
+    } catch(InvalidShapeException ex) { 
+      //expected
+    }
+    
+    if(reader instanceof JtsWKTReader) {
+      try {
+        txt = readFirstLineFromRsrc("/fiji.wkt.txt");
+        reader.read(txt);
+        fail("should throw invalid exception");
+      } catch(InvalidShapeException ex) { 
+        //expected
+      }
+    }
+  }
+
+  @Test
+  public void testParseVsInvalidExceptions() throws Exception
+  {
+    testParseVsInvalidExceptions(SpatialContext.GEO.getWktShapeParser());
+    testParseVsInvalidExceptions(JtsSpatialContext.GEO.getWktShapeParser());
   }
   
 


### PR DESCRIPTION
we should use the exceptions for ‘read’ consistently.  It should be:

ParseException: use this if we were unable to parse the input value

InvalidShapeException: use this if we *can* read it, but the value is invalid

——

This lets us throw InvalidShape from readIfSupported
