### PR TITLE
move supported format info from SpatialContent to a helper object

### DIFF
--- a/src/main/java/com/spatial4j/core/context/SpatialContextFactory.java
+++ b/src/main/java/com/spatial4j/core/context/SpatialContextFactory.java
@@ -215,6 +215,33 @@ public class SpatialContextFactory {
       throw new RuntimeException("Unable to find format class", ex);
     }
   }
+  
+
+  public SupportedFormats makeFormats(SpatialContext ctx) {
+    checkDefaultFormats();  // easy to override
+    
+    List<ShapeReader> read = new ArrayList<ShapeReader>(readers.size());
+    for (Class<? extends ShapeReader> clazz : readers) {
+      try {
+        read.add(makeClassInstance(clazz, ctx, this));
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+    
+    List<ShapeWriter> write = new ArrayList<ShapeWriter>(writers.size());
+    for (Class<? extends ShapeWriter> clazz : writers) {
+      try {
+        write.add(makeClassInstance(clazz, ctx, this));
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+    
+    return new SupportedFormats(
+        Collections.unmodifiableList(read), 
+        Collections.unmodifiableList(write));
+  }
 
   /**
    * If no formats were defined in the config, this will make sure GeoJSON and WKT are registered
@@ -262,30 +289,6 @@ public class SpatialContextFactory {
 
   public BinaryCodec makeBinaryCodec(SpatialContext ctx) {
     return makeClassInstance(binaryCodecClass, ctx, this);
-  }
-
-  public List<ShapeReader> makeReaders(SpatialContext ctx) {
-    List<ShapeReader> registry = new ArrayList<ShapeReader>(readers.size());
-    for (Class<? extends ShapeReader> clazz : readers) {
-      try {
-        registry.add(makeClassInstance(clazz, ctx, this));
-      } catch (Exception ex) {
-        throw new RuntimeException(ex);
-      }
-    }
-    return Collections.unmodifiableList(registry);
-  }
-
-  public List<ShapeWriter> makeWriters(SpatialContext ctx) {
-    List<ShapeWriter> registry = new ArrayList<ShapeWriter>(writers.size());
-    for (Class<? extends ShapeWriter> clazz : writers) {
-      try {
-        registry.add(makeClassInstance(clazz, ctx, this));
-      } catch (Exception ex) {
-        throw new RuntimeException(ex);
-      }
-    }
-    return Collections.unmodifiableList(registry);
   }
 
 

--- a/src/main/java/com/spatial4j/core/io/SupportedFormats.java
+++ b/src/main/java/com/spatial4j/core/io/SupportedFormats.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.spatial4j.core.io;
+
+import java.util.List;
+
+import com.spatial4j.core.context.SpatialContext;
+import com.spatial4j.core.shape.Shape;
+
+/**
+ * Information about the formats a {@link SpatialContext} can read/write
+ */
+public class SupportedFormats {
+
+  private final List<ShapeReader> readers;
+  private final List<ShapeWriter> writers;
+
+  private final ShapeReader wktReader;
+  private final ShapeWriter wktWriter;
+  
+  private final ShapeReader geoJsonReader;
+  private final ShapeWriter geoJsonWriter;
+  
+  public SupportedFormats(List<ShapeReader> readers, List<ShapeWriter> writers) {
+    this.readers = readers;
+    this.writers = writers;
+
+    wktReader = getReader(ShapeIO.WKT);
+    wktWriter = getWriter(ShapeIO.WKT);
+    
+    geoJsonReader = getReader(ShapeIO.GeoJSON);
+    geoJsonWriter = getWriter(ShapeIO.GeoJSON);
+  }
+  
+  public List<ShapeReader> getReaders() {
+    return readers;
+  }
+
+  public List<ShapeWriter> getWriters() {
+    return writers;
+  }
+  
+  public ShapeReader getReader(String fmt) {
+    for(ShapeReader f : readers) {
+      if(fmt.equals(f.getFormatName())) {
+        return f;
+      }
+    }
+    return null;
+  }
+
+  public ShapeWriter getWriter(String fmt) {
+    for(ShapeWriter f : writers) {
+      if(fmt.equals(f.getFormatName())) {
+        return f;
+      }
+    }
+    return null;
+  }
+  
+  public ShapeReader getWktReader() {
+    return wktReader;
+  }
+
+  public ShapeWriter getWktWriter() {
+    return wktWriter;
+  }
+
+  public ShapeReader getGeoJsonReader() {
+    return geoJsonReader;
+  }
+
+  public ShapeWriter getGeoJsonWriter() {
+    return geoJsonWriter;
+  }
+
+  public Shape read(String value) {
+    for(ShapeReader format : readers) {
+      Shape v = format.readIfSupported(value);
+      if(v!=null) {
+        return v;
+      }
+    }
+    return null;
+  }
+}

--- a/src/test/java/com/spatial4j/core/context/SpatialContextFactoryTest.java
+++ b/src/test/java/com/spatial4j/core/context/SpatialContextFactoryTest.java
@@ -122,7 +122,7 @@ public class SpatialContextFactoryTest {
         "spatialContextFactory", JtsSpatialContextFactory.class.getName(),
         "readers", CustomWktShapeParser.class.getName());
     
-    assertTrue( ctx.getReader(ShapeIO.WKT) instanceof CustomWktShapeParser );
+    assertTrue( ctx.getFormats().getReader(ShapeIO.WKT) instanceof CustomWktShapeParser );
   }
   
   @Test

--- a/src/test/java/com/spatial4j/core/io/GeoJSONReadWriteTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeoJSONReadWriteTest.java
@@ -39,8 +39,8 @@ public class GeoJSONReadWriteTest {
   public void setUp() {
     ctx = JtsSpatialContext.GEO;
     gb = new GeomBuilder();
-    reader = ctx.getReader(ShapeIO.GeoJSON);
-    writer = ctx.getWriter(ShapeIO.GeoJSON);
+    reader = ctx.getFormats().getReader(ShapeIO.GeoJSON);
+    writer = ctx.getFormats().getWriter(ShapeIO.GeoJSON);
 
     Assert.assertNotNull(reader);
     Assert.assertNotNull(writer);

--- a/src/test/java/com/spatial4j/core/io/ShapeFormatTest.java
+++ b/src/test/java/com/spatial4j/core/io/ShapeFormatTest.java
@@ -57,8 +57,8 @@ public class ShapeFormatTest {
   }
   
   public void testCommon(SpatialContext ctx, String name) throws Exception {
-    ShapeReader reader = ctx.getReader(name);
-    ShapeWriter writer = ctx.getWriter(name);
+    ShapeReader reader = ctx.getFormats().getReader(name);
+    ShapeWriter writer = ctx.getFormats().getWriter(name);
     assertNotNull(reader);
     assertNotNull(writer);
     testReadAndWriteTheSame(ctx.makePoint(10, 20),reader,writer);
@@ -73,8 +73,8 @@ public class ShapeFormatTest {
   }
 
   public void testJTS(JtsSpatialContext ctx, String name) throws Exception {
-    ShapeReader reader = ctx.getReader(name);
-    ShapeWriter writer = ctx.getWriter(name);
+    ShapeReader reader = ctx.getFormats().getReader(name);
+    ShapeWriter writer = ctx.getFormats().getWriter(name);
     Shape shape = null;
     
 //    


### PR DESCRIPTION
rather than have readers/writers directly on the SpatialContext, lets hold them in a helper class (SupportedFormats)

this lets us have direct access to

getGeoJsonWriter()[etc] without making a mess of the SpatialContext class