### PR TITLE
Upgrade jeo to version 0.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,9 @@
     </dependency>
         
     <dependency>
-      <groupId>org.jeo</groupId>
+      <groupId>io.jeo</groupId>
       <artifactId>jeo</artifactId>
-      <version>0.5</version>
+      <version>0.6</version>
       <scope>test</scope>
     </dependency>
 
@@ -152,14 +152,6 @@
     </dependency>
 
   </dependencies>
-  
-  <repositories>
-    <repository>
-      <id>boundless</id>
-      <name>Boundless Maven Repository</name>
-      <url>http://repo.boundlessgeo.com/main</url>
-    </repository>
-  </repositories>
   
   <build>
     

--- a/src/test/java/com/spatial4j/core/io/GeoJSONReadWriteTest.java
+++ b/src/test/java/com/spatial4j/core/io/GeoJSONReadWriteTest.java
@@ -17,7 +17,7 @@ package com.spatial4j.core.io;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.jeo.geom.GeomBuilder;
+import io.jeo.geom.GeomBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
- Includes a package renaming from org.jeo to io.jeo
- Artifacts also available in maven central to removing boundless
repository reference.