### PR TITLE
Moved DatelineRule from JtsWKTReader to top level.

### DIFF
--- a/src/main/java/com/spatial4j/core/context/jts/DatelineRule.java
+++ b/src/main/java/com/spatial4j/core/context/jts/DatelineRule.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spatial4j.core.context.jts;
+
+/**
+ * Indicates the algorithm used to process JTS Polygons and JTS LineStrings for detecting dateline
+ * crossings. It only applies when geo=true.
+ */
+public enum DatelineRule {
+  /** No polygon will cross the dateline. */
+  none,
+
+  /**
+   * Adjacent points with an x (longitude) difference that spans more than half way around the
+   * globe will be interpreted as going the other (shorter) way, and thus cross the dateline.
+   */
+  width180, // TODO is there a better name that doesn't have '180' in it?
+
+  /**
+   * For rectangular polygons, the point order is interpreted as being counter-clockwise (CCW).
+   * However, non-rectangular polygons or other shapes aren't processed this way; they use the
+   * {@link #width180} rule instead. The CCW rule is specified by OGC Simple Features
+   * Specification v. 1.2.0 section 6.1.11.1.
+   */
+  ccwRect
+}

--- a/src/main/java/com/spatial4j/core/context/jts/JtsSpatialContext.java
+++ b/src/main/java/com/spatial4j/core/context/jts/JtsSpatialContext.java
@@ -52,6 +52,7 @@ public class JtsSpatialContext extends SpatialContext {
   protected final boolean allowMultiOverlap;
   protected final boolean useJtsPoint;
   protected final boolean useJtsLineString;
+  protected final DatelineRule datelineRule;
 
   /**
    * Called by {@link com.spatial4j.core.context.jts.JtsSpatialContextFactory#newSpatialContext()}.
@@ -63,6 +64,7 @@ public class JtsSpatialContext extends SpatialContext {
     this.allowMultiOverlap = factory.allowMultiOverlap;
     this.useJtsPoint = factory.useJtsPoint;
     this.useJtsLineString = factory.useJtsLineString;
+    this.datelineRule = factory.datelineRule;
   }
 
   /**
@@ -74,6 +76,13 @@ public class JtsSpatialContext extends SpatialContext {
    */
   public boolean isAllowMultiOverlap() {
     return allowMultiOverlap;
+  }
+
+  /**
+   * Returns the rule used to handle geometry objects that have dateline crossing considerations.
+   */
+  public DatelineRule getDatelineRule() {
+    return datelineRule;
   }
 
   @Override
@@ -209,7 +218,7 @@ public class JtsSpatialContext extends SpatialContext {
    * needs to have done some verification/normalization of the coordinates by now, if any.
    */
   public JtsGeometry makeShape(Geometry geom) {
-    return makeShape(geom, true/*dateline180Check*/, allowMultiOverlap);
+    return makeShape(geom, datelineRule != DatelineRule.none, allowMultiOverlap);
   }
 
   public GeometryFactory getGeometryFactory() {

--- a/src/main/java/com/spatial4j/core/context/jts/JtsSpatialContextFactory.java
+++ b/src/main/java/com/spatial4j/core/context/jts/JtsSpatialContextFactory.java
@@ -40,7 +40,7 @@ import com.vividsolutions.jts.geom.impl.CoordinateArraySequenceFactory;
  * <DL>
  * <DT>datelineRule</DT>
  * <DD>width180(default)|ccwRect|none
- *  -- see {@link com.spatial4j.core.io.jts.JtsWKTReader.DatelineRule}</DD>
+ *  -- see {@link DatelineRule}</DD>
  * <DT>validationRule</DT>
  * <DD>error(default)|none|repairConvexHull|repairBuffer0
  *  -- see {@link com.spatial4j.core.io.jts.JtsWKTReader.ValidationRule}</DD>
@@ -65,7 +65,7 @@ public class JtsSpatialContextFactory extends SpatialContextFactory {
   public CoordinateSequenceFactory coordinateSequenceFactory = CoordinateArraySequenceFactory.instance();
 
   //ignored if geo=false
-  public JtsWKTReader.DatelineRule datelineRule = JtsWKTReader.DatelineRule.width180;
+  public DatelineRule datelineRule = DatelineRule.width180;
 
   public JtsWKTReader.ValidationRule validationRule = JtsWKTReader.ValidationRule.error;
   public boolean autoIndex = false;

--- a/src/test/java/com/spatial4j/core/context/SpatialContextFactoryTest.java
+++ b/src/test/java/com/spatial4j/core/context/SpatialContextFactoryTest.java
@@ -22,6 +22,7 @@ import com.spatial4j.core.context.jts.JtsSpatialContextFactory;
 import com.spatial4j.core.distance.CartesianDistCalc;
 import com.spatial4j.core.distance.GeodesicSphereDistCalc;
 import com.spatial4j.core.io.ShapeIO;
+import com.spatial4j.core.context.jts.DatelineRule;
 import com.spatial4j.core.io.jts.JtsWKTReader;
 import com.spatial4j.core.shape.impl.RectangleImpl;
 
@@ -96,7 +97,7 @@ public class SpatialContextFactoryTest {
     assertTrue(ctx.isNormWrapLongitude());
     assertEquals(2.0, ctx.getGeometryFactory().getPrecisionModel().getScale(), 0.0);
     assertTrue(CustomWktShapeParser.once);//cheap way to test it was created
-    assertEquals(JtsWKTReader.DatelineRule.ccwRect,
+    assertEquals(DatelineRule.ccwRect,
         ((JtsWKTReader)ctx.getWktShapeParser()).getDatelineRule());
     assertEquals(JtsWKTReader.ValidationRule.repairConvexHull,
         ((JtsWKTReader)ctx.getWktShapeParser()).getValidationRule());

--- a/src/test/java/com/spatial4j/core/context/jts/JtsSpatialContextTest.java
+++ b/src/test/java/com/spatial4j/core/context/jts/JtsSpatialContextTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spatial4j.core.context.jts;
+
+import com.spatial4j.core.shape.jts.JtsGeometry;
+import com.vividsolutions.jts.geom.GeometryCollection;
+import com.vividsolutions.jts.geom.Polygon;
+import org.jeo.geom.Geom;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class JtsSpatialContextTest {
+
+    @Test
+    public void testDatelineRule() {
+        Polygon polygon = Geom.build().points(-179, -90, 179, -90, 179, 90, -179, 90).toPolygon();
+
+        JtsSpatialContextFactory factory = new JtsSpatialContextFactory();
+        factory.datelineRule = DatelineRule.width180;
+
+        JtsSpatialContext ctx = factory.newSpatialContext();
+        JtsGeometry shp = ctx.makeShape((Polygon) polygon.clone());
+        assertTrue(shp.getGeom() instanceof GeometryCollection);
+
+        factory.datelineRule = DatelineRule.none;
+        ctx = factory.newSpatialContext();
+        shp = ctx.makeShape(polygon);
+        assertTrue(shp.getGeom() instanceof Polygon);
+    }
+}

--- a/src/test/java/com/spatial4j/core/io/JtsWKTReaderShapeParserTest.java
+++ b/src/test/java/com/spatial4j/core/io/JtsWKTReaderShapeParserTest.java
@@ -21,8 +21,8 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.context.jts.JtsSpatialContextFactory;
 import com.spatial4j.core.exception.InvalidShapeException;
+import com.spatial4j.core.context.jts.DatelineRule;
 import com.spatial4j.core.io.jts.JtsWKTReaderShapeParser;
-import com.spatial4j.core.io.jts.JtsWKTReader;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
 import org.junit.Test;
@@ -34,7 +34,7 @@ public class JtsWKTReaderShapeParserTest extends RandomizedTest {
   final SpatialContext ctx;
   {
     JtsSpatialContextFactory factory = new JtsSpatialContextFactory();
-    factory.datelineRule = JtsWKTReader.DatelineRule.ccwRect;
+    factory.datelineRule = DatelineRule.ccwRect;
     factory.readers.clear();
     factory.readers.add( JtsWKTReaderShapeParser.class );
     ctx = factory.newSpatialContext();

--- a/src/test/java/com/spatial4j/core/io/JtsWktShapeParserTest.java
+++ b/src/test/java/com/spatial4j/core/io/JtsWktShapeParserTest.java
@@ -20,6 +20,7 @@ package com.spatial4j.core.io;
 import com.spatial4j.core.context.jts.JtsSpatialContext;
 import com.spatial4j.core.context.jts.JtsSpatialContextFactory;
 import com.spatial4j.core.exception.InvalidShapeException;
+import com.spatial4j.core.context.jts.DatelineRule;
 import com.spatial4j.core.io.jts.JtsWKTReader;
 import com.spatial4j.core.shape.Rectangle;
 import com.spatial4j.core.shape.Shape;
@@ -101,7 +102,7 @@ public class JtsWktShapeParserTest extends WktShapeParserTest {
 
   @Test
   public void polyToRectCcwRule() throws ParseException {
-    JtsSpatialContext ctx = new JtsSpatialContextFactory() { { datelineRule = JtsWKTReader.DatelineRule.ccwRect;} }.newSpatialContext();
+    JtsSpatialContext ctx = new JtsSpatialContextFactory() { { datelineRule = DatelineRule.ccwRect;} }.newSpatialContext();
     //counter-clockwise
     assertEquals(ctx.readShapeFromWkt("POLYGON((160 0, -170 0, -170 10, 160 10, 160 0))"),
         ctx.makeRectangle(160, -170, 0, 10));


### PR DESCRIPTION
The dateline rule set on the spatial contedxt factory is now used to configure
dateline handling when calling the non-explicit version of makeShape(). This
change also simplifies the calls to makeShape from JtsWktReader, rather than
check the dateline rule explicitly it can rely on the value set on the spatial
context.

Signed-off-by: jdeolive <jdeolive@gmail.com>